### PR TITLE
Autofolding feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 Quickly toggle folding on all block comments with `ctrl+shift+/`.
 
 ![screenshot](https://i.cloudup.com/rrXaFlda9t.gif)
+
+# Autofolding
+
+You can specify comments autofolding on file opening with next config option
+
+```
+"fold-comments":
+  autofold: true
+```

--- a/lib/fold-comments.coffee
+++ b/lib/fold-comments.coffee
@@ -4,26 +4,20 @@ module.exports = FoldComments =
     atom.commands.add "atom-workspace", "fold-comments:fold-all": => @fold()
     atom.commands.add "atom-workspace", "fold-comments:unfold-all": => @unfold()
 
-  foldAs: (func) ->
-    editor = atom.workspace.getActiveTextEditor()
+  toggle: -> @foldAs('toggle')
 
-    for row in [0..editor.getLastBufferRow()]
-      foldable = editor.isFoldableAtBufferRow(row)
-      is_comment = editor.isBufferRowCommented(row)
+  fold: -> @foldAs('fold')
 
-      if foldable and is_comment
-        if func is 'toggle'
-          editor.toggleFoldAtBufferRow(row)
-        else if func is 'fold'
-          editor.foldBufferRow(row)
-        else if func is 'unfold'
-          editor.unfoldBufferRow(row)
+  unfold: -> @foldAs('unfold')
 
-  toggle: ->
-    @foldAs('toggle')
+  foldAs: (mode, editor) ->
+    editor ||= atom.workspace.getActiveTextEditor()
 
-  fold: ->
-    @foldAs('fold')
+    eachFoldable = (f) ->
+      for row in [0..editor.getLastBufferRow()]
+        f(row) if editor.isFoldableAtBufferRow(row) && editor.isBufferRowCommented(row)
 
-  unfold: ->
-    @foldAs('unfold')
+    switch mode
+      when 'toggle' then eachFoldable (row) -> editor.toggleFoldAtBufferRow(row)
+      when 'fold' then eachFoldable (row) -> editor.foldBufferRow(row)
+      when 'unfold' then eachFoldable (row) -> editor.unfoldBufferRow(row)

--- a/lib/fold-comments.coffee
+++ b/lib/fold-comments.coffee
@@ -1,8 +1,18 @@
 module.exports = FoldComments =
+  config:
+    autofold:
+      type: 'boolean'
+      default: false
+
   activate: (state) ->
     atom.commands.add "atom-workspace", "fold-comments:toggle": => @toggle()
     atom.commands.add "atom-workspace", "fold-comments:fold-all": => @fold()
     atom.commands.add "atom-workspace", "fold-comments:unfold-all": => @unfold()
+
+    if atom.config.get('fold-comments.autofold')
+      atom.workspace.observeTextEditors (editor) =>
+        editor.displayBuffer.tokenizedBuffer.onDidTokenize =>
+          @foldAs('fold', editor)
 
   toggle: -> @foldAs('toggle')
 

--- a/package.json
+++ b/package.json
@@ -3,13 +3,6 @@
   "main": "./lib/fold-comments",
   "version": "0.4.0",
   "description": "Quickly toggle folding on all comments",
-  "activationCommands": {
-    "atom-workspace": [
-      "fold-comments:toggle",
-      "fold-comments:fold-all",
-      "fold-comments:unfold-all"
-    ]
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jenius/atom-fold-comments.git"


### PR DESCRIPTION
Hello there. 

I've added configuration options for automatic folding of all comments on file opening. It's disabled by default but you can enable it via "fold-comments.autofold" option. see updated README for details