### PR TITLE
Fixed indented comment block folding

### DIFF
--- a/lib/fold-comments.coffee
+++ b/lib/fold-comments.coffee
@@ -27,8 +27,11 @@ module.exports = FoldComments =
     editor ||= atom.workspace.getActiveTextEditor()
 
     eachFoldable = (f) ->
+      lastFoldedRow = -2
       for row in [0..editor.getLastBufferRow()]
-        f(row) if editor.isFoldableAtBufferRow(row) && editor.isBufferRowCommented(row)
+        if editor.isFoldableAtBufferRow(row) && editor.isBufferRowCommented(row) && lastFoldedRow + 1 != row
+          f(row)
+          lastFoldedRow = row
 
     switch mode
       when 'toggle' then eachFoldable (row) -> editor.toggleFoldAtBufferRow(row)


### PR DESCRIPTION
Do not mark as foldable if last row was marked already. Fixes folding indented comment blocks that have two consecutive foldable rows (for some reason).
